### PR TITLE
Add ApplicationID and async parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wayfound",
-    "version": "0.2.10",
+    "version": "2.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wayfound",
-            "version": "0.2.10",
+            "version": "2.0.5",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayfound",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Wayfound AI Agent management platform",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/session.d.ts
+++ b/src/session.d.ts
@@ -1,6 +1,7 @@
 export interface SessionParams {
   wayfoundApiKey?: string;
   agentId?: string;
+  applicationId?: string | null;
   visitorId?: string | null;
   visitorDisplayName?: string | null;
   accountId?: string | null;

--- a/src/session.d.ts
+++ b/src/session.d.ts
@@ -16,6 +16,7 @@ export interface SessionMessage {
 
 export interface CompleteSessionParams {
   messages?: SessionMessage[];
+  async?: boolean;
 }
 
 export class Session {

--- a/src/session.js
+++ b/src/session.js
@@ -11,6 +11,7 @@ export class Session {
    * @param {Object} params - The parameters for creating a new Session instance.
    * @param {string} [params.wayfoundApiKey=process.env.WAYFOUND_API_KEY] - The Wayfound API key. Defaults to the environment variable WAYFOUND_API_KEY.
    * @param {string} [params.agentId=process.env.WAYFOUND_AGENT_ID] - The agent ID. Defaults to the environment variable WAYFOUND_AGENT_ID.
+   * @param {string|null} [params.applicationId=null] - The application ID. Optional parameter.
    * @param {string|null} [params.visitorId=null] - The visitor's unique identifier.
    * @param {string|null} [params.visitorDisplayName=null] - The display name of the visitor.
    * @param {string|null} [params.accountId=null] - The account's unique identifier.
@@ -19,6 +20,7 @@ export class Session {
   constructor({
     wayfoundApiKey = process.env.WAYFOUND_API_KEY,
     agentId = process.env.WAYFOUND_AGENT_ID,
+    applicationId = process.env.WAYFOUND_APPLICATION_ID,
     visitorId = null,
     visitorDisplayName = null,
     accountId = null,
@@ -26,6 +28,7 @@ export class Session {
   }) {
     this.wayfoundApiKey = wayfoundApiKey;
     this.agentId = agentId;
+    this.applicationId = applicationId;
     this.visitorId = visitorId;
     this.visitorDisplayName = visitorDisplayName;
     this.accountId = accountId;
@@ -35,7 +38,7 @@ export class Session {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.wayfoundApiKey}`,
       "X-SDK-Language": SDK_LANGUAGE,
-      "X-SDK-Version": "2.0.4",
+      "X-SDK-Version": "2.0.5",
     };
   }
 
@@ -86,6 +89,10 @@ export class Session {
 
     if (this.accountDisplayName) {
       payload.accountDisplayName = this.accountDisplayName;
+    }
+
+    if (this.applicationId) {
+      payload.applicationId = this.applicationId;
     }
 
     try {

--- a/src/session.js
+++ b/src/session.js
@@ -46,6 +46,7 @@ export class Session {
    * Completes the session by sending the request to Wayfound.
    * @param {Object} params - Parameters for completing the session.
    * @param {Array} [params.messages=[]] - An array of messages to include in the completed session.
+   * @param {boolean} [params.async=true] - Whether to process the session asynchronously. If false, the request will block until processing is complete.
    * @returns {Promise<Object>} - A promise that resolves with the Axios response when the session has been completed.
    * @throws {Error} - Throws an error if the completion request fails.
    *
@@ -60,7 +61,9 @@ export class Session {
    *            content: 'Hello!'
    *          }
    *       },
-   *     ]})
+   *     ],
+   *     async: false // Request will block until processing is complete
+   *     })
    *     .then(() => {
    *         console.log('Session completed successfully');
    *     })
@@ -68,11 +71,12 @@ export class Session {
    *         console.error('Error completing session:', error);
    *     });
    */
-  async completeSession({ messages = [] }) {
+  async completeSession({ messages = [], async = true }) {
     const sessionUrl = `${WAYFOUND_SESSION_COMPLETED_URL}`;
     const payload = {
       agentId: this.agentId,
       messages: messages,
+      async: async,
     };
 
     if (this.visitorId) {


### PR DESCRIPTION
This pull request introduces minor enhancements and version updates to the Wayfound SDK, primarily focusing on expanding the `Session` class functionality and updating version numbers. The most significant changes are the addition of support for an `applicationId` and an `async` parameter for session completion requests.

**Session class enhancements:**

* Added optional `applicationId` parameter to the `Session` constructor and ensured it is included in the payload if provided. [[1]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59R14) [[2]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59R23-R31) [[3]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59R98-R101)
* Updated JSDoc comments to document the new `applicationId` and `async` parameters. [[1]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59R14) [[2]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59L38-R49) [[3]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59L60-R79)
* Added support for an `async` parameter to the `completeSession` method, allowing callers to specify synchronous or asynchronous processing. [[1]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59L38-R49) [[2]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59L60-R79) [[3]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59R98-R101)

**Version updates:**

* Bumped SDK version from `2.0.4` to `2.0.5` in both `package.json` and request headers. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-ec75bebb1866d99ac5e8cd807271745cd953b9df4a04878239ec836582672e59L38-R49)

Tested using `npm pack` and a local Wayfound server